### PR TITLE
Add CSRF_TRUSTED_ORIGINS

### DIFF
--- a/azureproject/production.py
+++ b/azureproject/production.py
@@ -4,6 +4,7 @@ import os
 # Configure the domain name using the environment variable
 # that Azure automatically creates for us.
 ALLOWED_HOSTS = [os.environ['WEBSITE_HOSTNAME']] if 'WEBSITE_HOSTNAME' in os.environ else []
+CSRF_TRUSTED_ORIGINS = ['https://'+ os.environ['WEBSITE_HOSTNAME']] if 'WEBSITE_HOSTNAME' in os.environ else []
 DEBUG = False
 
 # WhiteNoise configuration


### PR DESCRIPTION
Last time I tried out "python manage.py createsuperuser" in production was a few weeks ago. I created a superuser and then logged in at /admin site. It worked. When I look at back at that project, I was using Django 3.x version. 

Today, I tried the same steps and failed with "CSRF verification failed." when trying to login to /admin site. After some tracing, I see that I'm now using Django 4.0.2 version (latest) and that as of 4.0 release ([notes](https://docs.djangoproject.com/en/4.0/releases/4.0/#csrf-trusted-origins-changes-4-0)) you need to use CSRF_TRUSTED_ORIGINS and it has to be with "https://" part.

Only putting it in the production.py as it doesn't seem to be needed in local env.