### PR TITLE
Update settings.py to pull SECRET_KEY from env

### DIFF
--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-7ppocbnx@w71dcuinn*t^_mzal(t@o01v3fee27g%rg18fc5d@'
+SECRET_KEY = os.getenv('SECRET_KEY', 'django-insecure-7ppocbnx@w71dcuinn*t^_mzal(t@o01v3fee27g%rg18fc5d@')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
## Purpose

Currently the settings.py hardcodes SECRET_KEY with a note to make sure to change it in production. A best practice is to get SECRET_KEY from the environment variables, and that makes it much easier to change in production without accidentally checking it in. This PR changes the line to get SECRET_KEY from environment variables while still defaulting to the insecure key value.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[X] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

If the server works, then the settings were loaded correctly:

```
python manage.py runserver
```


## Other Information

I had to make this change in [my fork of this sample](https://github.com/pamelafox/msdocs-django-postgresql-sample-app-azd) which adds support for the Azure Developer CLI, as I needed to define a SECRET_KEY environment variable in the Bicep template. This change should generally make it easier for anyone who is deploying a Django app.
