### PR TITLE
CSRF settings

### DIFF
--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -28,6 +28,8 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
+if 'CODESPACE_NAME' in os.environ:
+    CSRF_TRUSTED_ORIGINS = [f'https://{os.getenv("CODESPACE_NAME")}-8000.{os.getenv("GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN")}']
 
 # Application definition
 


### PR DESCRIPTION
## Purpose

Currently, due to the way Codespace "local" URLs work, it's not possible to log in to the Django admin panel. A CSRF error displays instead:

<img width="1246" alt="Screenshot 2022-11-16 at 9 31 08 AM" src="https://user-images.githubusercontent.com/297042/202315508-23cd3d43-817a-4991-986d-bacc88d802eb.png">

This PR overrides CSRF_TRUSTED_ORIGINS when the app is using the development settings and when an environment variable is present that indicates its running in Codespaces. This is similar to how the override is done in the production settings already.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

Both in Codespaces and locally:

* pip install -r requirements.txt
* python manage.py migrate
* python manage.py createsuperuser
* python manage.py runserver
* Try logging into /admin with your superuser credentials. It should work!
