### PR TITLE
Use burstable tier

### DIFF
--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -192,8 +192,8 @@ resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2022-01-20-pr
   tags: tags
   name: pgServerName
   sku: {
-    name: 'Standard_D2ds_v4'
-    tier: 'GeneralPurpose'
+    name: 'Standard_B1ms'
+    tier: 'Burstable'
   }
   properties: {
     version: '13'

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -196,7 +196,7 @@ resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2022-01-20-pr
     tier: 'Burstable'
   }
   properties: {
-    version: '13'
+    version: '12'
     administratorLogin: 'django'
     administratorLoginPassword: databasePassword
     storage: {
@@ -230,15 +230,6 @@ resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2022-01-20-pr
 resource djangoDatabase 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2022-01-20-preview' = {
   parent: postgresServer
   name: 'django'
-}
-
-resource postgresServer_AllowAllWindowsAzureIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2022-01-20-preview' = {
-  parent: postgresServer
-  name: 'AllowAllWindowsAzureIps'
-  properties: {
-    startIpAddress: '0.0.0.0'
-    endIpAddress: '0.0.0.0'
-  }
 }
 
 output WEB_URI string = 'https://${web.properties.defaultHostName}'


### PR DESCRIPTION
## Purpose

I discovered a few differences between the PostgreSQL configuration in the Bicep files versus the configuration deployed by the WebApp + Database template in the tutorial.

* Sku/Tier should be Burstable, Standard_B1ms
* PostgreSQL version should be 12
* There should be no firewall rule to allow all Azure IPs (since we're using a VNET)

After making the change, I deployed this repo and compared the properties to the tutorial version. I also compared the exported template JSON and all the differences seem to be name related.

**Tutorial deployment:**

<img width="1369" alt="Screenshot 2022-11-29 at 2 49 18 PM" src="https://user-images.githubusercontent.com/297042/204665885-51c97181-ef35-400d-836b-6898a9881bcf.png">

**Bicep deployment:**

<img width="1367" alt="Screenshot 2022-11-29 at 3 32 37 PM" src="https://user-images.githubusercontent.com/297042/204671502-5e8e890a-eb51-4b00-a8af-2562d53b7373.png">


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

`azd up`

And then after successful deploy, confirm the tier is Burstable. Website should be reachable and usable (you can add a new restaurant).
