### PR TITLE
Add M1 support for devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 ARG VARIANT=3
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+FROM --platform=amd64 mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 
 RUN curl -fsSL https://aka.ms/install-azd.sh | bash
 


### PR DESCRIPTION
## Purpose

This change makes it possible to open the devcontainer on an M1 Mac. The same change was made for all the official azd samples:

https://github.com/Azure/azure-dev/pull/1284/files

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Open in VS Code on M1 Mac, specify to open in devcontainer.
* Wait for devcontainer to successfully build.
* Follow readme to ensure local dev and SQLtools extension works.
