### PR TITLE
Updates for azd release and Oryx issue

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,11 @@
 ARG VARIANT=3
 FROM --platform=amd64 mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 
-RUN curl -fsSL https://aka.ms/install-azd.sh | bash
-
 ENV PYTHONUNBUFFERED 1
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends postgresql-client
+    && apt-get -y install --no-install-recommends postgresql-client \
+     && apt-get update && apt-get install -y xdg-utils \
+     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://aka.ms/install-azd.sh | bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"name": "Python 3 & PostgreSQL",
+	"name": "msdocs-django-postgresql-sample-app",
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
@@ -37,9 +37,6 @@
 		"python.testing.pytestPath": "/usr/local/py-utils/bin/pytest"
 	},
 	"features": {
-        "ghcr.io/devcontainers/features/azure-cli:1": {
-            "version": "latest"
-        },
 		"ghcr.io/devcontainers/features/github-cli:1": {
             "version": "latest"
         }
@@ -55,9 +52,9 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [
 		8000, 5432
-	]
+	],
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "",
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	// "remoteUser": "vscode"
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
 }

--- a/.github/workflows/azure-dev.yaml
+++ b/.github/workflows/azure-dev.yaml
@@ -11,6 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/azure-dev-cli-apps:latest
+    env:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/azure-dev.yaml
+++ b/.github/workflows/azure-dev.yaml
@@ -15,11 +15,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Log in with Azure
+      - name: Log in with Azure (Federated Credentials)
+        if: ${{ env.AZURE_CLIENT_ID != '' }}
+        run: |
+          azd login `
+            --client-id "$Env:AZURE_CLIENT_ID" `
+            --federated-credential-provider "github" `
+            --tenant-id "$Env:AZURE_TENANT_ID"
+        shell: pwsh
+
+      - name: Log in with Azure (Client Credentials)
+        if: ${{ env.AZURE_CREDENTIALS != '' }}
         run: |
           $info = $Env:AZURE_CREDENTIALS | ConvertFrom-Json -AsHashtable;
           Write-Host "::add-mask::$($info.clientSecret)"
-
           azd login `
             --client-id "$($info.clientId)" `
             --client-secret "$($info.clientSecret)" `

--- a/.github/workflows/azure-dev.yaml
+++ b/.github/workflows/azure-dev.yaml
@@ -16,9 +16,17 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Log in with Azure
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+        run: |
+          $info = $Env:AZURE_CREDENTIALS | ConvertFrom-Json -AsHashtable;
+          Write-Host "::add-mask::$($info.clientSecret)"
+
+          azd login `
+            --client-id "$($info.clientId)" `
+            --client-secret "$($info.clientSecret)" `
+            --tenant-id "$($info.tenantId)"
+        shell: pwsh
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Azure Dev Provision
         run: azd provision --no-prompt

--- a/.github/workflows/azure-dev.yaml
+++ b/.github/workflows/azure-dev.yaml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -92,7 +92,7 @@ resource web 'Microsoft.Web/sites@2022-03-01' = {
     serverFarmId: appServicePlan.id
     siteConfig: {
       alwaysOn: true
-      linuxFxVersion: 'PYTHON|3.10'
+      linuxFxVersion: 'PYTHON|3.9'
       ftpsState: 'Disabled'
       appCommandLine: 'startup.sh'
     }


### PR DESCRIPTION
## Purpose

(This is same PR for both flask and django, using same PR description for both)

This PR makes various updates to the azd-related files in the repo that are necessary for the latest version of azd:
https://github.com/Azure/azure-dev/releases/tag/azure-dev-cli_0.5.0-beta.1

Specifically: The latest azd now takes care of the login itself instead of requiring a dependency on the azure CLI. That means that azure-cli can be removed from the devcontainer and should be replaced in the Github workflow with azd login. It also means the devcontainer must be built with the "xdg-utils" package so that azd can pop open a browser from the container.

In addition, this PR changes the Python runtime version in the infra folders from 3.10 to 3.9. Unfortunately, there's currently an issue with 3.10/3.11 and the PostgreSQL psycopg package (https://github.com/microsoft/Oryx/issues/1767) so the version needs to be bumped down to 3.9 as a workaround. The learn.microsoft.com tutorial also uses 3.9, so this change makes it match the tutorial.

In the future, it'd be great to bump all our samples up to 3.10, given it's been out and stable for a while:
https://www.python.org/downloads/


## Does this introduce a breaking change?

```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Clone the repo
* Open in a Dev Container in VS Code or open in Github Codespaces
* Once it opens, confirm `azd` command works and app can be run.
* Confirm Github action workflow successfully logins and deploys the app. (Confirmed on my fork of the repo, the workflows aren't currently configured for the Azure-samples parent).
