### PR TITLE
Fix - remove default leak

### DIFF
--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv('SECRET_KEY', 'django-insecure-7ppocbnx@w71dcuinn*t^_mzal(t@o01v3fee27g%rg18fc5d@')
+SECRET_KEY = os.getenv('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
Fix: 

1. Remove leaked secret
2. Instead use `python -c 'import secrets; print(secrets.token_hex())'` after deployment and set App Setting of `SECRET_KEY`