### PR TITLE
Add SECRET_KEY for local development

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,3 +2,4 @@ DBNAME=<database name>
 DBHOST=<database-hostname>
 DBUSER=<db-user-name>
 DBPASS=<db-password>
+SECRET_KEY=<secret key>

--- a/.env.sample.devcontainer
+++ b/.env.sample.devcontainer
@@ -2,3 +2,4 @@ DBNAME=app
 DBHOST=localhost
 DBUSER=app_user
 DBPASS=app_password
+SECRET_KEY=

--- a/README.md
+++ b/README.md
@@ -29,15 +29,20 @@ then it's best to first [create a Python virtual environment](https://docs.pytho
     python3 -m pip install -r requirements.txt
     ```
 
-2. Create an `.env` file using `.env.sample` as a guide. Set the value of `DBNAME` to the name of an existing database in your local PostgreSQL instance. Set the values of `DBHOST`, `DBUSER`, and `DBPASS` as appropriate for your local PostgreSQL instance. If you're in the devcontainer, copy the values from `.env.sample.devcontainer`.
+2. Create an `.env` file using `.env.sample` as a guide. Set the value of `DBNAME` to the name of an existing database in your local PostgreSQL instance. Set the values of `DBHOST`, `DBUSER`, and `DBPASS` as appropriate for your local PostgreSQL instance. If you're in the devcontainer, copy the values from `.env.sample.devcontainer`. 
 
-3. Run the migrations: (or use VS Code "Run" button and select "Migrate")
+3. In the `.env` file, fill in a secret value for `SECRET_KEY`. You can use this command to generate an appropriate value:
+
+    ```shell
+    python -c 'import secrets; print(secrets.token_hex())'
+
+4. Run the migrations: (or use VS Code "Run" button and select "Migrate")
 
     ```shell
     python3 manage.py migrate
     ```
 
-4. Run the local server: (or use VS Code "Run" button and select "Run server")
+5. Run the local server: (or use VS Code "Run" button and select "Run server")
 
     ```shell
     python3 manage.py runserver


### PR DESCRIPTION
## Purpose

The recent change to SECRET_KEY = os.getenv('SECRET_KEY') with no default value means that the local server will error out ('SECRET_KEY cannot be empty'). This PR adds SECRET_KEY to the `.env.sample*` files, and instructions about generating it in the README.

I think we *could* potentially put the insecure key in the .env files, since the deployed version *shouldn't* use it, but maybe people would be tempted to use it for prod instead of generating a new one. This change requires a PR to the tutorial as well to add the secret generation step for local dev as well.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix (for local dev)
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code
* Follow the instructions to run locally
* Website should run successfully
