### PR TITLE
Port to using azd feature

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,5 @@
-ARG VARIANT=3
-FROM --platform=amd64 mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
-
-ENV PYTHONUNBUFFERED 1
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.10
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends postgresql-client \
-     && apt-get update && apt-get install -y xdg-utils \
-     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
-
-RUN curl -fsSL https://aka.ms/install-azd.sh | bash
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
 	"service": "app",
 	"workspaceFolder": "/workspace",
 	"features": {
+		"ghcr.io/azure/azure-dev/azd:latest": {}
     },
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,12 +5,6 @@ services:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
-      args:
-        # [Choice] Python version: 3, 3.8, 3.7, 3.6
-        VARIANT: "3.10"
-        # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
-        USER_UID: 1000
-        USER_GID: 1000
 
     volumes:
       - ..:/workspace:cached


### PR DESCRIPTION
## Purpose

There's now an azd feature for dev containers, which will automatically download the appropriate azd for your architecture (arm/amd) so platform emulation is no longer needed.
This PR updates the dev container to use that feature and also removes some other unnecessary bits.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Open in Dev Container in VS Code, confirm azd command works, server can be run
* Open in GitHub Codespaces, ditto