### PR TITLE
Update python-test.yaml's ubuntu, postgresql versions to enable dependabot to update django 

### DIFF
--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -17,7 +17,7 @@ jobs:
         python_version: ["3.10", "3.11"]
     services:
       postgres:
-        image: postgres:12
+        image: postgres:17
         env:
           POSTGRES_PASSWORD: postgres
         ports:

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-20.04"]
+        os: ["ubuntu-24.04"]
         python_version: ["3.10", "3.11"]
     services:
       postgres:


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Dependabot is dying because python-test.yaml is using an old version of postgresql (that has been retired) which Django utils can't use any more
* GitHub Actions was brownouting to highlight the need to bump the Ubuntu version from 20.04 to 24.04, the latest LTS
* This fixes both issues, and allows Dependabot to do its thing

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
fork
run GitHub actions
Enjoy happy success 
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->