### PR TITLE
Azure Managed Redis updates

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   app:
     build:
@@ -9,28 +7,50 @@ services:
     volumes:
       - ..:/workspace:cached
 
-    # Overrides default command so things don't shut down after the process ends.
+    # Keep the development container running.
     command: sleep infinity
 
-    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
-    network_mode: service:db
+    # Start supporting services before the app container.
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+
+    networks:
+      - app-network
 
   db:
-    image: postgres:latest
+    image: postgres:17
     restart: unless-stopped
+
     volumes:
       - postgres-data:/var/lib/postgresql/data
+
     environment:
       POSTGRES_DB: app
       POSTGRES_USER: app_user
       POSTGRES_PASSWORD: app_password
 
-    # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
-    # (Adding the "ports" property to this file will not forward from a Codespace.)
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U app_user -d app"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+    networks:
+      - app-network
 
   redis:
-    image: redis
+    image: redis:7-alpine
     restart: unless-stopped
+
+    networks:
+      - app-network
 
 volumes:
   postgres-data:
+
+networks:
+  app-network:
+    driver: bridge

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -17,8 +17,7 @@ services:
       redis:
         condition: service_started
 
-    networks:
-      - app-network
+    network_mode: service:db
 
   db:
     image: postgres:17
@@ -38,19 +37,9 @@ services:
       timeout: 5s
       retries: 10
 
-    networks:
-      - app-network
-
   redis:
     image: redis:7-alpine
     restart: unless-stopped
 
-    networks:
-      - app-network
-
 volumes:
   postgres-data:
-
-networks:
-  app-network:
-    driver: bridge

--- a/.env
+++ b/.env
@@ -2,5 +2,5 @@ DBNAME=app
 DBHOST=localhost
 DBUSER=app_user
 DBPASS=app_password
-CACHELOCATION=redis://redis:6379/0
+CACHELOCATION=redis://redis:10000/0
 SECRET_KEY=secret_key

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ description: This is a Python web app using the Django framework and the Azure D
 
 This is a Python web app using the Django framework and the Azure Database for PostgreSQL relational database service. The Django app is hosted in a fully managed Azure App Service. This app is designed to be be run locally and then deployed to Azure. You can either deploy this project by following the tutorial [*Deploy a Python (Django or Flask) web app with PostgreSQL in Azure*](https://docs.microsoft.com/azure/app-service/tutorial-python-postgresql-app) or by using the [Azure Developer CLI (azd)](https://learn.microsoft.com/azure/developer/azure-developer-cli/overview) according to the instructions below.
 
-Additionally, the sample application demonstrates Azure Redis Cache access by caching the restaurant details page for 60 seconds. You can add the Azure Redis Cache integration in the [secure-by-default web app + database creation wizard](https://portal.azure.com/?feature.customportal=false#create/Microsoft.AppServiceWebAppDatabaseV3), and it's also included in the [AZD template](https://github.com/Azure-Samples/python-app-service-postgresql-infra).
+Additionally, the sample application demonstrates Azure Managed Redis access by caching the restaurant details page for 60 seconds. You can add the Azure Managed Redis integration in the [secure-by-default web app + database creation wizard](https://portal.azure.com/?feature.customportal=false#create/Microsoft.AppServiceWebAppDatabaseV3), and it's also included in the [AZD template](https://github.com/Azure-Samples/python-app-service-postgresql-infra).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The [requirements.txt](./requirements.txt) has the following packages, all used 
 | [pyscopg2-binary](https://pypi.org/project/psycopg-binary/) | PostgreSQL database adapter for Python. |
 | [python-dotenv](https://pypi.org/project/python-dotenv/) | Read key-value pairs from .env file and set them as environment variables. In this sample app, those variables describe how to connect to the database locally. <br><br> This package is used in the [manage.py](./manage.py) file to load environment variables. |
 | [whitenoise](https://pypi.org/project/whitenoise/) | Static file serving for WSGI applications, used in the deployed app. <br><br> This package is used in the [azureproject/production.py](./azureproject/production.py) file, which configures production settings. |
-| [django-redis](https://pypi.org/project/django-redis/) | Redis cache backend for Django. |
+| [django-redis](https://pypi.org/project/django-redis/) | Django integration for Azure Managed Redis and Redis-compatible caching backends. |
 
 ## Run the sample
 

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -275,20 +275,25 @@ resource dbserver 'Microsoft.DBforPostgreSQL/flexibleServers@2022-01-20-preview'
 }
 
 // The Redis cache is configured to the minimum pricing tier
-resource redisCache 'Microsoft.Cache/redis@2024-11-01' = {
+resource redisCache 'Microsoft.Cache/redisEnterprise@2026-05-01-preview' = {
   name: '${appName}-cache'
   location: location
+  sku: {
+    name: 'Balanced_B0'
+  }
   properties: {
-    sku: {
-      name: 'Basic'
-      family: 'C'
-      capacity: 0
-    }
-    redisConfiguration: {}
-    enableNonSslPort: false
-    redisVersion: '6'
+    minimumTlsVersion: '1.2'
     publicNetworkAccess: 'Disabled'
   }
+
+  // Azure Managed Redis authentication
+  resource redisDatabase 'databases@2026-05-01-preview' = {
+      name: 'default'
+      properties: {
+      accessKeysAuthentication: 'Enabled'
+      }
+    }
+
 }
 
 // The App Service plan is configured to the B1 pricing tier
@@ -430,7 +435,7 @@ resource cacheConnector 'Microsoft.ServiceLinker/linkers@2024-04-01' = {
     clientType: 'python'
     targetService: {
       type: 'AzureResource'
-      id:  resourceId('Microsoft.Cache/Redis/Databases', redisCache.name, '0')
+      id: redisCache::redisDatabase.id
     }
     authInfo: {
       authType: 'accessKey'

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -148,7 +148,7 @@ resource privateDnsZoneDB 'Microsoft.Network/privateDnsZones@2024-06-01' = {
   }  
 }
 
-// Resources needed to secure Redis Cache behind a private endpoint
+// Resources needed to secure Azure Managed Redis behind a private endpoint
 resource cachePrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-03-01' = {
   name: '${appName}-cache-privateEndpoint'
   location: location
@@ -161,7 +161,7 @@ resource cachePrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-03-01' = 
         name: '${appName}-cache-privateEndpoint'
         properties: {
           privateLinkServiceId: redisCache.id
-          groupIds: ['redisCache']
+          groupIds: ['redisEnterprise']
         }
       }
     ]
@@ -181,7 +181,7 @@ resource cachePrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-03-01' = 
   }
 }
 resource privateDnsZoneCache 'Microsoft.Network/privateDnsZones@2024-06-01' = {
-  name: 'privatelink.redis.cache.windows.net'
+  name: 'privatelink.redis.azure.net'
   location: 'global'
   dependsOn: [
     virtualNetwork
@@ -274,7 +274,7 @@ resource dbserver 'Microsoft.DBforPostgreSQL/flexibleServers@2022-01-20-preview'
   ]
 }
 
-// The Redis cache is configured to the minimum pricing tier
+// Azure Managed Redis is configured to the minimum pricing tier
 resource redisCache 'Microsoft.Cache/redisEnterprise@2026-05-01-preview' = {
   name: '${appName}-cache'
   location: location
@@ -282,18 +282,16 @@ resource redisCache 'Microsoft.Cache/redisEnterprise@2026-05-01-preview' = {
     name: 'Balanced_B0'
   }
   properties: {
+    encryption: {}
     minimumTlsVersion: '1.2'
     publicNetworkAccess: 'Disabled'
   }
+}
 
-  // Azure Managed Redis authentication
-  resource redisDatabase 'databases@2026-05-01-preview' = {
-      name: 'default'
-      properties: {
-      accessKeysAuthentication: 'Enabled'
-      }
-    }
-
+// The default Redis Enterprise database is platform-managed; reference it by ID.
+resource redisDatabase 'Microsoft.Cache/redisEnterprise/databases@2026-05-01-preview' existing = {
+  parent: redisCache
+  name: 'default'
 }
 
 // The App Service plan is configured to the B1 pricing tier
@@ -435,7 +433,7 @@ resource cacheConnector 'Microsoft.ServiceLinker/linkers@2024-04-01' = {
     clientType: 'python'
     targetService: {
       type: 'AzureResource'
-      id: redisCache::redisDatabase.id
+      id: redisDatabase.id
     }
     authInfo: {
       authType: 'accessKey'


### PR DESCRIPTION
Updated [resources.bicep](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to use Azure Managed Redis Enterprise conventions.
Changed private endpoint group ID to redisEnterprise.
Updated Redis private DNS zone to privatelink.redis.azure.net.
Added encryption block on Redis Enterprise resource.
Updated Service Linker target to the Redis database resource ID.
Updated README wording to remove legacy Redis Cache phrasing.